### PR TITLE
Consider content unique by source

### DIFF
--- a/lib/content.rb
+++ b/lib/content.rb
@@ -2,7 +2,7 @@ require 'nokogiri'
 require 'digest'
 
 class Content < Struct.new(:path, :title, :html, :id)
-  def self.load_all(dir)
+  def self.load_all(dir, source)
     paths = Dir["#{dir}/**/*.html"]
 
     paths.map {|path|
@@ -13,7 +13,7 @@ class Content < Struct.new(:path, :title, :html, :id)
         path,
         title,
         html,
-        Digest::MD5.hexdigest(path),
+        Digest::MD5.hexdigest(source + path),
       )
     }
   end

--- a/sync.rb
+++ b/sync.rb
@@ -21,7 +21,7 @@ def main
   logger = Logger.new(STDOUT)
   logger.formatter = ColoredLoggingFormatter
 
-  contents = Content.load_all(CONTENT_DIR)
+  contents = Content.load_all(CONTENT_DIR, EXTERNAL_CONTENT_SOURCE_ID)
   api = FederatedSearchAPI.new(logger: logger)
 
   contents.group_by(&:id).each do |id, cs|


### PR DESCRIPTION
It's possible for External Content Records to be unintentionally deleted when using this GHA action with multiple External Content Sources and content has the same path.

Consider the content unique if the path is unique for the configured External Content Source.