### PR TITLE
send only text instead of full html

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Working directory. See `target-base-url` for when to use this.
 Required: yes \
 Default: `.`
 
+### `content-css-selector`
+
+CSS selector that will be passed to [Nokogiri’s `at` method](https://nokogiri.org/rdoc/Nokogiri/XML/Node.html#method-i-at). Only this node from each HTML file will sent to Zendesk Guide. By default, we post all text found in `<body>`, but you can set this selector to something more narrow (for example, `main` or `article`).
+
+Required: no
+Default: `body`
+
 ## Example Workflow
 
 This workflow uses Hugo to build a static site, then synchronizes the HTML files with the Guide search index:
@@ -66,13 +73,13 @@ jobs:
 
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Hugo site
         uses: klakegg/actions-hugo@1.0.0
 
       - name: Sync with the Guide Search Index
-        uses: zendesk/index-content-in-guide-action@v3
+        uses: zendesk/index-content-in-guide-action@v6
         with:
           auth: ${{ secrets.ZENDESK_AUTH }}
           zendesk-subdomain: my-zendesk-subdomain
@@ -80,6 +87,7 @@ jobs:
           type-id: some-type-id
           content-dir: public # defaults to `.`
           target-base-url: https://example.com
+          content-css-selector: main # defaults to `body`
 ```
 
 If you want to index multiple External Content types you can use the [matrix feature](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix) of Github Actions:
@@ -104,13 +112,13 @@ jobs:
 
     steps:
       - name: Check out source code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build Hugo site
         uses: klakegg/actions-hugo@1.0.0
 
       - name: Sync with the Guide Search Index
-        uses: zendesk/index-content-in-guide-action@v3
+        uses: zendesk/index-content-in-guide-action@v6
         with:
           auth: ${{ secrets.ZENDESK_AUTH }}
           zendesk-subdomain: my-zendesk-subdomain
@@ -118,4 +126,5 @@ jobs:
           type-id: ${{ matrix.type-id }}         # <----
           content-dir: ${{ matrix.content-dir }} # <----
           target-base-url: https://example.com
+          content-css-selector: main # defaults to `body`
 ```

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,10 @@ inputs:
   zendesk-subdomain:
     description: The subdomain of your Zendesk account.
     required: true
+  content-css-selector:
+    description: CSS selector for the section of HTML that will be sent to Guide as text
+    required: false
+    default: 'body'
 runs:
   using: docker
   image: Dockerfile
@@ -36,3 +40,4 @@ runs:
     ZENDESK_AUTH: ${{ inputs.auth }}
     ZENDESK_BASE_URL: "https://${{ inputs.zendesk-subdomain }}.zendesk.com"
     TARGET_BASE_URL: ${{ inputs.target-base-url }}
+    CONTENT_CSS_SELECTOR: ${{ inputs.content-css-selector }}

--- a/lib/content.rb
+++ b/lib/content.rb
@@ -1,18 +1,19 @@
 require 'nokogiri'
 require 'digest'
 
-class Content < Struct.new(:path, :title, :html, :id)
+class Content < Struct.new(:path, :title, :body, :id)
   def self.load_all(dir, source)
     paths = Dir["#{dir}/**/*.html"]
 
     paths.map {|path|
-      html = File.read(path)
-      title = Nokogiri::HTML.parse(html).title
+      html = Nokogiri::HTML.parse(File.read(path))
+      title = html.title
+      body = html.at(CONTENT_CSS_SELECTOR).text
 
       new(
         path,
         title,
-        html,
+        body,
         Digest::MD5.hexdigest(source + path),
       )
     }

--- a/sync.rb
+++ b/sync.rb
@@ -12,6 +12,7 @@ EXTERNAL_CONTENT_SOURCE_ID = ENV.fetch("EXTERNAL_CONTENT_SOURCE_ID")
 EXTERNAL_CONTENT_TYPE_ID = ENV.fetch("EXTERNAL_CONTENT_TYPE_ID")
 CONTENT_DIR = ENV.fetch("CONTENT_DIR", ".")
 WORKING_DIR = ENV.fetch("WORKING_DIR", ".")
+CONTENT_CSS_SELECTOR = ENV.fetch("CONTENT_CSS_SELECTOR", "body")
 
 MAX_BODY_LENGTH = 9000
 
@@ -43,7 +44,7 @@ def main
       external_id: content.id,
       url: content.url,
       title: content.title,
-      body: content.html.slice(0...MAX_BODY_LENGTH),
+      body: content.body.slice(0...MAX_BODY_LENGTH),
       type_id: EXTERNAL_CONTENT_TYPE_ID,
       source_id: EXTERNAL_CONTENT_SOURCE_ID,
       locale: "en-us",


### PR DESCRIPTION
External content records have a length limit of 10000 characters (and in this action, we conservatively send only 9000 characters). Many of these characters will be HTML tags, which are not useful for searches.

Additionally, we allow setting a CSS selector parameter to narrow down what’s being sent. By default, we are sending the whole `<body>`, but it includes elements like navigation and footer, which makes difficult searching for terms mentioned in them. This value can be set to `main` or `article` to focus on the most relevant part of a page.