### PR TITLE
Add AI-ready documentation files

### DIFF
--- a/.cursor/rules/00-core.mdc
+++ b/.cursor/rules/00-core.mdc
@@ -1,0 +1,9 @@
+---
+description: Core project conventions
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Read and follow all instructions in the root `AGENTS.md` file.
+Read and follow all security requirements in `SECURITY.md`.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+# Copilot Instructions
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,3 @@
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,93 @@
+# index-content-in-guide-action
+
+A Docker-based GitHub Action written in Ruby that synchronizes local HTML files into the Zendesk Guide Federated Search index using the External Content API. It creates, updates, and deletes search records to keep Guide in sync with the local content source.
+
+## Setup & Commands
+
+```bash
+# Install dependencies
+bundle install
+
+# Run the action locally (requires .env with all variables)
+ruby sync.rb
+
+# Run tests (CI integration test — runs the full action against test/hello.html)
+# Triggered automatically on push via .github/workflows/test.yml
+```
+
+Local development requires a `.env` file (gitignored) with the required environment variables. See `action.yml` for the full list of inputs mapped to env vars.
+
+## Environment Variables
+
+| Variable | Source Input | Description |
+|---|---|---|
+| `TARGET_BASE_URL` | `target-base-url` | Base URL prefixed to each HTML file path |
+| `EXTERNAL_CONTENT_SOURCE_ID` | `source-id` | Zendesk External Content Source ID |
+| `EXTERNAL_CONTENT_TYPE_ID` | `type-id` | Zendesk External Content Type ID |
+| `ZENDESK_BASE_URL` | `zendesk-subdomain` | Constructed as `https://<subdomain>.zendesk.com` |
+| `ZENDESK_AUTH` | `auth` | Basic auth credentials (`email:password`), Base64-encoded |
+| `CONTENT_DIR` | `content-dir` | Directory of HTML files to index (default: `.`) |
+| `WORKING_DIR` | `working-dir` | Working directory for relative path resolution (default: `.`) |
+| `CONTENT_CSS_SELECTOR` | `content-css-selector` | Nokogiri CSS selector for body text (default: `body`) |
+
+## Code Conventions
+
+- Ruby idioms: `snake_case` methods/variables, `PascalCase` classes, `SCREAMING_SNAKE_CASE` constants
+- Use `Struct.new` for simple data classes (`Content`)
+- Use `include Enumerable` + `each` for collection wrappers (`RecordList`)
+- Environment variables accessed via `ENV.fetch` (raises on missing) or `ENV.fetch(key, default)`
+- `excon` gem for HTTP — use keyword arguments (`path:`, `body:`, `expects:`, `idempotent:`)
+- `nokogiri` for HTML parsing — use `html.at(selector).text` for body extraction
+- All logging through the Ruby `Logger` with `ColoredLoggingFormatter`
+
+## Testing
+
+- No unit test framework in use — the integration test in `.github/workflows/test.yml` runs the full action against `test/hello.html` on every push
+- `test/` contains fixture HTML files used by the CI workflow
+- When adding test fixtures, place HTML files in `test/`
+
+## Do
+
+- Use `ENV.fetch("VAR")` (not `ENV["VAR"]`) so missing variables raise clearly
+- Truncate `body` to `MAX_BODY_LENGTH` (9000) before sending to the API
+- Filter existing records by both `source_id` AND `type_id` before comparing (see `RecordList`)
+- Detect and raise on duplicate content IDs before syncing
+- Use `idempotent: true` on `PUT`/`DELETE` Excon calls for safe retries
+- Keep `lib/` classes single-responsibility (API client, collection, value object, parser)
+- Use `persistent: true` on the Excon connection for efficiency across multiple API calls
+
+## Don't
+
+- Don't add runtime logic to `sync.rb`; delegate to `lib/` classes
+- Don't use `ENV["VAR"]` (returns nil on missing); use `ENV.fetch`
+- Don't send body content longer than `MAX_BODY_LENGTH` to the API
+- Don't skip the duplicate-ID check before syncing
+- Don't modify `Gemfile.lock` manually; run `bundle install` or `bundle update`
+- Don't commit `.env` files (already in `.gitignore`)
+
+## Architecture
+
+See `ARCHITECTURE.md` for system architecture, component relationships, and data flow.
+
+## Security
+
+See `SECURITY.md` for mandatory security requirements, credential handling rules, and escalation triggers.
+
+## Safety & Permissions
+
+Allowed without approval:
+- Read/list files
+- Run `bundle install`
+- Run the action locally with test credentials
+
+Ask before:
+- Adding or updating gems (`bundle add`, `bundle update`)
+- Modifying `action.yml` inputs or the Dockerfile base image
+- Changing the Zendesk API endpoint paths or auth scheme
+- Modifying `.github/workflows/test.yml`
+
+## PR & Commit Guidelines
+
+- No enforced Jira ticket prefix (see recent merged PRs for examples)
+- PR titles use plain English: `Add CODEOWNERS file`, `Bump nokogiri from X to Y`
+- Keep PRs focused; one logical change per PR

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,76 @@
+# index-content-in-guide-action
+
+## System Overview
+
+This repository is a Docker-based GitHub Action that synchronizes local HTML files into Zendesk Guide's Federated Search index. It reads HTML files from a configurable directory, extracts titles and body text using Nokogiri, then calls the Zendesk External Content API to create, update, or delete search records. The action is designed to run as a CI step after a static-site build (e.g., Hugo) to keep Help Center search results up to date.
+
+## Architecture Diagram
+
+```mermaid
+graph TD
+    GHA["GitHub Actions<br>(workflow step)"] -->|"docker run<br>env vars"| Container["Docker Container<br>(sync.rb)"]
+    Container --> Content["Content<br>(lib/content.rb)<br>Glob + Nokogiri parse"]
+    Container --> RecordList["RecordList<br>(lib/record_list.rb)<br>Paginated fetch"]
+    Container --> API["FederatedSearchAPI<br>(lib/federated_search_api.rb)<br>Excon HTTP client"]
+    API -->|"HTTPS REST"| Zendesk["Zendesk Guide<br>External Content API"]
+    RecordList --> API
+    Content -->|"create / update"| API
+    RecordList -->|"delete stale"| API
+```
+
+## Component Map
+
+| File | Responsibility |
+|------|---------------|
+| `sync.rb` | Entry point — orchestrates load, diff, create/update/delete cycle |
+| `action.yml` | GitHub Action definition — maps action inputs to env vars |
+| `Dockerfile` | Docker image build — installs gems, sets entrypoint to `sync.rb` |
+| `lib/federated_search_api.rb` | HTTP client wrapping Zendesk External Content API endpoints |
+| `lib/record_list.rb` | Enumerable over all existing records, handles cursor-based pagination |
+| `lib/search_record.rb` | Value object for a single Zendesk external content record |
+| `lib/content.rb` | Parses HTML files into `Content` structs (title, body, id, url) |
+| `lib/colored_logging_formatter.rb` | ANSI-colored Logger formatter for CI output readability |
+| `test/` | Fixture HTML files used by the CI integration test |
+
+## Request Flow
+
+1. GitHub Actions runs the Docker container, injecting all inputs as environment variables
+2. `sync.rb` changes to `WORKING_DIR`, instantiates logger and loads all HTML files via `Content.load_all`
+3. `Content.load_all` globs `CONTENT_DIR/**/*.html`, parses each with Nokogiri, extracts title and `CONTENT_CSS_SELECTOR` text
+4. Each `Content` gets a deterministic ID: `MD5(source_id + file_path)`
+5. `sync.rb` validates no duplicate IDs exist across the loaded files (raises if found)
+6. `RecordList` fetches all existing Zendesk records matching `source_id` + `type_id`, handling cursor pagination
+7. For each local content item: if no matching record exists → `POST` (create); if record exists → `PUT` (update) and remove from the existing list
+8. Any records remaining in the existing list (not matched) are `DELETE`d (stale records)
+
+## Key Design Decisions
+
+### Docker-Based Action
+The action uses `runs: using: docker` rather than `composite` or `node`. This gives a stable, hermetic Ruby environment without requiring consumers to pre-install Ruby on their runners.
+
+### Deterministic Content IDs via MD5
+Content IDs are `MD5(source_id + file_path)`, not content hashes. This means the same file always gets the same ID regardless of content changes, enabling stable update-vs-create decisions. MD5 is used only as a stable identifier here, not for security.
+
+### Filter by Source and Type
+`RecordList` filters records by both `source_id` AND `type_id` even though the API returns all records for the account. This allows multiple action invocations with different type/source pairs to coexist without interfering.
+
+### Cursor-Based Pagination
+The Zendesk API returns paginated results. `RecordList` transparently handles `has_more` + `after_cursor` so callers see a flat `Enumerable`.
+
+## External Dependencies
+
+| Service | Protocol | Location | Purpose |
+|---------|----------|----------|---------|
+| Zendesk Guide External Content API | HTTPS REST | `lib/federated_search_api.rb` | Create/update/delete search index records |
+| GitHub Actions runner | Docker | `action.yml`, `Dockerfile` | Action execution environment |
+
+## Cross-Cutting Concerns
+
+### Configuration
+All configuration is via environment variables accessed through `ENV.fetch`. In the action, these come from `action.yml` input mappings. Locally, they come from a `.env` file loaded by `dotenv` (development group only).
+
+### Observability
+Structured logging via Ruby `Logger` with `ColoredLoggingFormatter`. Log levels used: `debug` (pagination cursors), `info` (progress), `warn` (deletions), `error` (API errors). All output goes to STDOUT for capture by the Actions runner.
+
+### Error Handling
+API errors are caught as `Excon::Error::Client`, the response body is logged at `error` level, and the exception is re-raised to fail the action step. This surfaces Zendesk API error messages directly in CI logs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# Claude Code Configuration
+
+Read and follow all instructions in `AGENTS.md` — the source of truth for coding conventions.
+Read and follow all instructions in `SECURITY.md` — mandatory security requirements.
+See `ARCHITECTURE.md` for system architecture and design decisions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,165 @@
+# AI Agent Security Standard
+
+This document defines mandatory security principles and restrictions for all AI coding assistants operating in this repository. All AI agents must follow these requirements without exception.
+
+**Authority:** Derived from [Zendesk Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/) and internal security policies.
+
+---
+
+## Core Security Mandate
+
+Security is a first-class requirement. Every code suggestion must be evaluated against these guidelines. If a request would result in insecure code:
+
+1. **Stop** and flag the security concern
+2. **Explain** why it's problematic
+3. **Propose** a secure alternative
+
+AI-generated code requires human review before merging.
+
+---
+
+## Absolute Prohibitions
+
+AI agents must **NEVER** do the following:
+
+### Secrets & Credentials
+- Hardcode secrets, credentials, API keys, tokens, or passwords in source code
+- Store secrets in version control (`.env` files, `action.yml` with real values)
+- Log, print, or expose secret values — including `ZENDESK_AUTH` (which contains email:password)
+- Expose credentials in URLs, log messages, or error output
+
+### Security Controls
+- Disable or weaken TLS certificate validation in Excon (`ssl_verify_peer: false`)
+- Bypass the `Authorization: Basic` header requirement for Zendesk API calls
+- Add `ALLOW_ALL` CORS headers or other permissive security bypasses
+
+### Dangerous Code Patterns
+- Use string interpolation to construct API paths from user-controlled input without sanitization
+- Use `eval()` or `exec()` with content from HTML files or env vars
+- Implement custom cryptographic logic (MD5 in this codebase is used only as a stable identifier, not for security)
+
+### Data Exposure
+- Log the value of `ZENDESK_AUTH`, `AUTH`, or any credential-containing variable
+- Expose raw Zendesk API error bodies to end users in a web context (logging to CI stdout is acceptable)
+- Send more than `MAX_BODY_LENGTH` characters of HTML body content to the API
+
+---
+
+## Required Security Patterns
+
+### Credential Handling
+
+```ruby
+# Correct: credentials from environment, never logged
+AUTH = ENV.fetch("ZENDESK_AUTH")
+headers = { "Authorization" => "Basic #{AUTH}" }
+```
+
+```ruby
+# NEVER: hardcode or log credentials
+AUTH = "my@email.com:mypassword"
+logger.info("Auth: #{AUTH}")
+```
+
+### API Error Logging
+
+```ruby
+# Correct: log the API error response body, not internal credential state
+rescue Excon::Error::Client => err
+  @logger.error(JSON.parse(err.response.body))
+  raise
+```
+
+```ruby
+# NEVER: include auth headers or request body containing credentials in error logs
+rescue Excon::Error::Client => err
+  @logger.error("Request headers: #{err.request[:headers]}")  # exposes auth
+```
+
+### Excon TLS
+
+```ruby
+# Correct: default Excon behavior (TLS verification enabled)
+@excon = Excon.new(BASE_URL, persistent: true, headers: headers)
+```
+
+```ruby
+# NEVER: disable certificate validation
+@excon = Excon.new(BASE_URL, ssl_verify_peer: false)
+```
+
+### Environment Variables
+
+```ruby
+# Correct: ENV.fetch raises on missing required vars
+TARGET_BASE_URL = ENV.fetch("TARGET_BASE_URL")
+```
+
+```ruby
+# Avoid: ENV[] returns nil silently, hiding misconfiguration
+TARGET_BASE_URL = ENV["TARGET_BASE_URL"]
+```
+
+---
+
+## Security Requirements by Domain
+
+### Authentication
+- The action uses HTTP Basic authentication for the Zendesk API (`Authorization: Basic <base64>`)
+- Credentials must always come from GitHub Actions secrets (never hardcoded)
+- The `auth` input to the action must reference a repository or organization secret in workflow YAML
+
+### Data Protection
+- `ZENDESK_AUTH` contains plaintext `email:password` — treat as a high-sensitivity secret
+- Body content is truncated to `MAX_BODY_LENGTH` before transmission (prevents oversized payloads)
+- Content IDs are derived from `MD5(source_id + path)` — this is an identifier, not a security control; do not treat it as tamper-proof
+
+### Communication Security
+- All Zendesk API calls use HTTPS (enforced by constructing `BASE_URL` from `https://...`)
+- Never add HTTP fallback or downgrade logic
+- Never pass `ssl_verify_peer: false` to Excon
+
+### Cryptography
+- MD5 is used only to generate stable, deterministic content identifiers — this is acceptable for this non-security use case
+- Do not use MD5 for password hashing, integrity verification, or any security-sensitive purpose
+
+### Infrastructure
+- The Docker image is built from `ruby:<version>` (see `Dockerfile`) — keep the base image up to date
+- Dependabot is used for gem vulnerability scanning (see merged bump PRs)
+- `Gemfile.lock` must be committed and kept updated via `bundle update`
+
+---
+
+## When to Stop and Escalate
+
+Stop, explain the concern, and recommend involving Security if a task requires:
+
+- Storing credentials anywhere other than GitHub Actions secrets
+- Disabling TLS certificate validation
+- Logging or exposing the value of `ZENDESK_AUTH` or similar credentials
+- Changing the authentication scheme for the Zendesk API
+- Adding new external HTTP calls to services not listed in `ARCHITECTURE.md`
+- Accessing or transmitting customer PII from HTML content
+
+---
+
+## Security Testing
+
+When generating features, include:
+
+- Tests for correct handling of missing required environment variables (should raise, not silently fail)
+- Tests that verify credentials are not leaked into log output
+- Tests for pagination edge cases in `RecordList` (empty results, single page, multiple pages)
+- Negative test cases for duplicate content ID detection
+
+---
+
+## References
+
+- [Minimum Baseline Security Standard](https://docs.google.com/document/d/17GZ9TpjKCt6WCdw3yxL44Ra_YscbOBVnVkUVGgx5Hz0/)
+- [Zendesk External Content API](https://developer.zendesk.com/api-reference/help_center/federated-search/external_content_records/)
+- [Excon gem documentation](https://github.com/excon/excon)
+
+---
+
+**Questions?** Reach out to the Security team or file a ticket via the Security Engagement process.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` — vendor-neutral conventions hub with project overview, environment variable reference, Ruby coding conventions, do/don't lists, and PR guidelines
- Add `ARCHITECTURE.md` — system diagram (Mermaid), component map, request flow, and key design decisions
- Add `SECURITY.md` — security constraints for AI agents covering credential handling, TLS requirements, and Zendesk-specific patterns
- Add thin spoke files for Claude Code (`CLAUDE.md`), GitHub Copilot (`.github/copilot-instructions.md`), Cursor (`.cursor/rules/00-core.mdc`), and Windsurf (`.windsurfrules`) that reference the hubs

## Test plan

- [ ] Review `AGENTS.md` for accuracy against `sync.rb`, `lib/`, and `action.yml`
- [ ] Review `ARCHITECTURE.md` diagram and component table for correctness
- [ ] Review `SECURITY.md` for alignment with Zendesk security standards
- [ ] Verify no source code was modified
- [ ] Confirm CI workflow still passes (`test.yml`)

---
Requested by @st33n via [zendesk/ai-repo#199](https://github.com/zendesk/ai-repo/issues/199)